### PR TITLE
[ADD] Support multiple vendor prefixes on one key

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,24 @@ if the vendor is `chrome` this compiles to:
 }
 ```
 
+---
+
+Add keys to multiple vendors by seperating them with | in the prefix
+
+```
+{
+  __chrome|opera__name: "SuperBlink"
+}
+```
+
+if the vendor is `chrome` or `opera`, this compiles to:
+
+```
+{
+  "name": "SuperBlink"
+}
+```
+
 ### Why are you not using mozillas [web-ext](https://github.com/mozilla/web-ext) package?
 
 * `webpack-webextension-plugin` should work for every browser in the same way.

--- a/manifest-utils/transform-vendor-keys.js
+++ b/manifest-utils/transform-vendor-keys.js
@@ -1,5 +1,5 @@
 const vendors = require('../vendors.json')
-const vendorRegExp = new RegExp(`^__(${vendors.join('|')})__(.*)`)
+const vendorRegExp = new RegExp(`^__((?:${vendors.join('|')})(?:(?:\\||__)(?:${vendors.join('|')}))*)__(.*)`)
 
 module.exports = function transformVendorKeys (manifest, vendor) {
   if (Array.isArray(manifest)) {
@@ -12,8 +12,9 @@ module.exports = function transformVendorKeys (manifest, vendor) {
       .reduce((manifest, [key, value]) => {
         const match = key.match(vendorRegExp)
         if (match) {
+          let vendors = match[1].split(new RegExp(`\\||__`)) // splits at | or __
           // Swap key with non prefixed name
-          if (match[1] === vendor) {
+          if (vendors.indexOf(vendor) > -1) {
             manifest[match[2]] = value
           }
         } else {

--- a/manifest-utils/transform-vendor-keys.js
+++ b/manifest-utils/transform-vendor-keys.js
@@ -1,5 +1,5 @@
 const vendors = require('../vendors.json')
-const vendorRegExp = new RegExp(`^__((?:${vendors.join('|')})(?:(?:\\||__)(?:${vendors.join('|')}))*)__(.*)`)
+const vendorRegExp = new RegExp(`^__((?:(?:${vendors.join('|')})\\|?)+)__(.*)`)
 
 module.exports = function transformVendorKeys (manifest, vendor) {
   if (Array.isArray(manifest)) {
@@ -12,7 +12,7 @@ module.exports = function transformVendorKeys (manifest, vendor) {
       .reduce((manifest, [key, value]) => {
         const match = key.match(vendorRegExp)
         if (match) {
-          let vendors = match[1].split(new RegExp(`\\||__`)) // splits at | or __
+          let vendors = match[1].split(new RegExp(`\\|`)) // splits at |
           // Swap key with non prefixed name
           if (vendors.indexOf(vendor) > -1) {
             manifest[match[2]] = value


### PR DESCRIPTION
While writing my manifest I noticed that certain times there were keys, not specific to one vendor, but the opposite: All support it except for e.g. Edge with _option_ui_. Having to copy this key 3 times for each vendor except Edge seemed rather inefficient and prone to errors.

So this:
```
  "__edge__options_page": "pages/options.html",
  "__chrome__options_ui": {
    "page": "pages/options.html",
    "open_in_tab": false
  },
  "__firefox__options_ui": {
    "page": "pages/options.html",
    "open_in_tab": false
  },
  "__opera__options_ui": {
    "page": "pages/options.html",
    "open_in_tab": false
  },
```
became this:
```
  "__edge__options_page": "pages/options.html",
  "__chrome|firefox|opera__options_ui": {
    "page": "pages/options.html",
    "open_in_tab": false
  },
```

**Commit message:**
Keys can contain multiple vendor prefixes seperated by either | or __
Trailing delimiters are intentionally not allowed to prevent confusion
with the __ delimiter for the whole vendor prefix.

Examples:
	Valid:
	__chrome__opera__key: value  -> key: value
	__edge|firefox__key: value   -> key: value

	Trailing |:
	__chrome|__key: value        -> __chrome|__key: value
	__chrome|opera|__key: value  -> __chrome|opera|__key: value
	__chrome__opera|__key: value -> opera|__key: value

	| after __ vendor prefix delimiter:
	__edge__|key: value          -> |key: value

	Trailing __:
	__firefox___key: value       -> _key: value
	__firefox____key: value      -> __key: value