### PR TITLE
[FIX] Split on | not working properly

### DIFF
--- a/manifest-utils/transform-vendor-keys.js
+++ b/manifest-utils/transform-vendor-keys.js
@@ -12,7 +12,7 @@ module.exports = function transformVendorKeys (manifest, vendor) {
       .reduce((manifest, [key, value]) => {
         const match = key.match(vendorRegExp)
         if (match) {
-          let vendors = match[1].split(new RegExp(`\\|`)) // splits at |
+          let vendors = match[1].split('|')
           // Swap key with non prefixed name
           if (vendors.indexOf(vendor) > -1) {
             manifest[match[2]] = value


### PR DESCRIPTION
Sorry for the oversight, but apparently in some cases the regex` \\| `won't work. Instead of trying to figure it out why I just simplyfied it to `split('|')` as the regex is by now unessesary anyway with just one character to split by.

**Also a note:** while you did made a new version of the plugin, the toolbox itself still has a peer dependency to v0.0.3